### PR TITLE
修复 Redis驱动实例化时未执行连接操作，造成部分缓存方法发生致命错误的问题

### DIFF
--- a/src/Connector/Redis.php
+++ b/src/Connector/Redis.php
@@ -49,6 +49,8 @@ class Redis extends AbstractCache
         if (!empty($options)) {
             $this->options = array_merge($this->options, $options);
         }
+
+        $this->connect();
     }
 
     /**
@@ -141,7 +143,6 @@ class Redis extends AbstractCache
      */
     public function get($name, $default = null)
     {
-        $this->connect();
         $value = self::$instance->get($this->getCacheKey($name));
         if (is_null($value) || false === $value) {
             return $default;
@@ -160,7 +161,6 @@ class Redis extends AbstractCache
      */
     public function set($name, $value, $ttl = null)
     {
-        $this->connect();
         if (is_null($ttl)) {
             $ttl = $this->options['expire'];
         }
@@ -222,8 +222,6 @@ class Redis extends AbstractCache
      */
     public function driver()
     {
-        $this->connect();
-
         return self::$instance;
     }
 }


### PR DESCRIPTION
比如Cache::delete('k')，报 PHP Fatal error:  Uncaught Error: Call to a member function delete()