### PR TITLE
修复 Redis驱动实例化时未执行连接操作，造成部分缓存方法发生致命错误的问题

### DIFF
--- a/src/Connector/Redis.php
+++ b/src/Connector/Redis.php
@@ -81,6 +81,8 @@ class Redis extends AbstractCache
      */
     public function inc($name, $step = 1)
     {
+        $this->connect();
+
         return self::$instance->incrBy($this->getCacheKey($name), $step);
     }
 
@@ -93,6 +95,8 @@ class Redis extends AbstractCache
      */
     public function dec($name, $step = 1)
     {
+        $this->connect();
+
         return self::$instance->decrBy($this->getCacheKey($name), $step);
     }
 
@@ -105,6 +109,8 @@ class Redis extends AbstractCache
      */
     public function pull($name, $default = null)
     {
+        $this->connect();
+
         $result = $this->get($name, false);
         if ($result) {
             $this->delete($name);
@@ -125,6 +131,8 @@ class Redis extends AbstractCache
      */
     public function remember($name, $value, $ttl = null)
     {
+        $this->connect();
+
         if (!$this->has($name)) {
             return $this->set($name, $value, $ttl);
         }
@@ -142,6 +150,7 @@ class Redis extends AbstractCache
     public function get($name, $default = null)
     {
         $this->connect();
+
         $value = self::$instance->get($this->getCacheKey($name));
         if (is_null($value) || false === $value) {
             return $default;
@@ -161,6 +170,7 @@ class Redis extends AbstractCache
     public function set($name, $value, $ttl = null)
     {
         $this->connect();
+
         if (is_null($ttl)) {
             $ttl = $this->options['expire'];
         }
@@ -186,6 +196,8 @@ class Redis extends AbstractCache
      */
     public function delete($name)
     {
+        $this->connect();
+
         return self::$instance->delete($this->getCacheKey($name));
     }
 
@@ -197,6 +209,8 @@ class Redis extends AbstractCache
      */
     public function has($name)
     {
+        $this->connect();
+
         return self::$instance->exists($this->getCacheKey($name));
     }
 
@@ -207,6 +221,8 @@ class Redis extends AbstractCache
      */
     public function clear()
     {
+        $this->connect();
+
         $keys = self::$instance->keys($this->options['prefix'].'*');
         if ($keys) {
             self::$instance->del(...$keys);


### PR DESCRIPTION
比如：delete，PHP Fatal error:  Uncaught Error: Call to a member function delete()